### PR TITLE
NEXT-33714 - allow PHPUnit 11 stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "mbezhanov/faker-provider-collection": "^2.0.1",
         "symfony/doctrine-bridge": "^5.4.7 | ^6 | ^7",
         "symfony/web-profiler-bundle": "^5.4 | ^6 | ^7",
-        "phpunit/phpunit": "^9.6 | ^10",
+        "phpunit/phpunit": "^9.6 | ^10 | ^11.4",
         "symfony/browser-kit": "^5.4 | ^6 | ^7"
     }
 }


### PR DESCRIPTION
Allows PHPUnit 11 to be used, starting from PHPUnit 11.4